### PR TITLE
Fix undefined type uint on musl

### DIFF
--- a/audiotags.cpp
+++ b/audiotags.cpp
@@ -188,7 +188,7 @@ bool audiotags_write_properties(TagLib_FileRefRef *fileRefRef, unsigned int len,
   properties.clear();
   f->file()->setProperties(properties);
 
-  for (uint i = 0; i < len; i++) {
+  for (unsigned int i = 0; i < len; i++) {
     TagLib::String field(fields_c[i], TagLib::String::Type::UTF8);
     TagLib::String value(values_c[i], TagLib::String::Type::UTF8);
 


### PR DESCRIPTION
Title is self explanatory, i believe

builds of this library fail on musl systems as `uint` is undefined over there